### PR TITLE
client_id has to be unique per client

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,8 +6,8 @@ define("BASE_URL", "https://forum.cfx.re");
 
 define("REDIRECT_URL", "http://localhost:8000");
 define("APP_NAME", "Your app");
-define("CLIENT_ID", uniqid());
-setcookie("CLIENT_ID", CLIENT_ID, time() + 60, "/");
+define("APP_CLIENT_ID", uniqid());
+setcookie("APP_CLIENT_ID", APP_CLIENT_ID, time() + 60, "/");
 
 // open our keypair
 $keypair = openssl_pkey_get_private(file_get_contents("keypair.pem"));
@@ -29,7 +29,7 @@ if (!isset($_GET["payload"]))
     $query = http_build_query([
         "auth_redirect"     => REDIRECT_URL,
         "application_name"  => APP_NAME,
-        "client_id"         => CLIENT_ID,
+        "client_id"         => APP_CLIENT_ID,
         "scopes"            => "session_info",
         "nonce"             => $nonce,
         "public_key"        => $pub
@@ -68,7 +68,7 @@ else
 
     curl_setopt($ch, CURLOPT_URL, BASE_URL . "/session/current.json");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . $_COOKIE["CLIENT_ID"]]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . $_COOKIE["APP_CLIENT_ID"]]);
 
     if (($body = curl_exec($ch)) == false)
     {

--- a/index.php
+++ b/index.php
@@ -6,8 +6,7 @@ define("BASE_URL", "https://forum.cfx.re");
 
 define("REDIRECT_URL", "http://localhost:8000");
 define("APP_NAME", "Your app");
-define("APP_CLIENT_ID", uniqid());
-setcookie("APP_CLIENT_ID", APP_CLIENT_ID, time() + 60, "/");
+$_SESSION["APP_CLIENT_ID"] = uniqid();
 
 // open our keypair
 $keypair = openssl_pkey_get_private(file_get_contents("keypair.pem"));
@@ -29,7 +28,7 @@ if (!isset($_GET["payload"]))
     $query = http_build_query([
         "auth_redirect"     => REDIRECT_URL,
         "application_name"  => APP_NAME,
-        "client_id"         => APP_CLIENT_ID,
+        "client_id"         => $_SESSION["APP_CLIENT_ID"],
         "scopes"            => "session_info",
         "nonce"             => $nonce,
         "public_key"        => $pub
@@ -68,7 +67,7 @@ else
 
     curl_setopt($ch, CURLOPT_URL, BASE_URL . "/session/current.json");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . $_COOKIE["APP_CLIENT_ID"]]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . $_SESSION["APP_CLIENT_ID"]]);
 
     if (($body = curl_exec($ch)) == false)
     {

--- a/index.php
+++ b/index.php
@@ -6,7 +6,14 @@ define("BASE_URL", "https://forum.cfx.re");
 
 define("REDIRECT_URL", "http://localhost:8000");
 define("APP_NAME", "Your app");
-define("APP_CLIENT_ID", "yourapp");
+
+if (!isset($_COOKIE["CLIENT_ID"])) {
+    define("CLIENT_ID", uniqid());
+    setcookie("CLIENT_ID", CLIENT_ID, time() + 60, "/");
+}
+else {
+    define("CLIENT_ID", $_COOKIE["CLIENT_ID"]);
+}
 
 // open our keypair
 $keypair = openssl_pkey_get_private(file_get_contents("keypair.pem"));
@@ -28,7 +35,7 @@ if (!isset($_GET["payload"]))
     $query = http_build_query([
         "auth_redirect"     => REDIRECT_URL,
         "application_name"  => APP_NAME,
-        "client_id"         => APP_CLIENT_ID,
+        "client_id"         => CLIENT_ID,
         "scopes"            => "session_info",
         "nonce"             => $nonce,
         "public_key"        => $pub
@@ -67,7 +74,7 @@ else
 
     curl_setopt($ch, CURLOPT_URL, BASE_URL . "/session/current.json");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . APP_CLIENT_ID]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . CLIENT_ID]);
 
     if (($body = curl_exec($ch)) == false)
     {

--- a/index.php
+++ b/index.php
@@ -6,14 +6,8 @@ define("BASE_URL", "https://forum.cfx.re");
 
 define("REDIRECT_URL", "http://localhost:8000");
 define("APP_NAME", "Your app");
-
-if (!isset($_COOKIE["CLIENT_ID"])) {
-    define("CLIENT_ID", uniqid());
-    setcookie("CLIENT_ID", CLIENT_ID, time() + 60, "/");
-}
-else {
-    define("CLIENT_ID", $_COOKIE["CLIENT_ID"]);
-}
+define("CLIENT_ID", uniqid());
+setcookie("CLIENT_ID", CLIENT_ID, time() + 60, "/");
 
 // open our keypair
 $keypair = openssl_pkey_get_private(file_get_contents("keypair.pem"));
@@ -74,7 +68,7 @@ else
 
     curl_setopt($ch, CURLOPT_URL, BASE_URL . "/session/current.json");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . CLIENT_ID]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Api-Key: " . $key, "User-Api-Client-Id: " . $_COOKIE["CLIENT_ID"]]);
 
     if (($body = curl_exec($ch)) == false)
     {


### PR DESCRIPTION
Noticed while testing and hinted by d-bubble that the `client_id` must be unique and shouldn't be hardcoded to a value.
Otherwise switching discourse account would lead to an [error](https://forum.cfx.re/t/discourse-user-api-oops/5068839)

Since we need it when the payload comes back, I propose so save it as a cookie for 60 seconds (may need to be longer to allow the user to log-in)